### PR TITLE
Drop setup-java gradle cache :construction_worker:

### DIFF
--- a/.github/workflows/check-solutions.yml
+++ b/.github/workflows/check-solutions.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-          cache: gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Check solutions


### PR DESCRIPTION
May interfere with setup-gradle caching as described in https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#incompatibility-with-other-caching-mechanisms.